### PR TITLE
Gitignore for build directory under windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ ui_*.h
 /lib/Release Client/
 /lib/Release/
 /lib/x64/
+build-*


### PR DESCRIPTION
I've created a gitignore rule for build (out-of-ource) direcotries of QtCreator, which is the default settings. Due I'm using this repo as a subrepo inside my project, it's pretty annoying that git is trying to commit build files, so I've added this rule.