### PR TITLE
Compile fix: warnings for VS2012 (+x64) and up.

### DIFF
--- a/lib/base.h
+++ b/lib/base.h
@@ -20,7 +20,7 @@
 
 /* configure lacking CRT features */
 #ifdef _MSC_VER
- #if _MSC_VER < 1700
+ #if _MSC_VER < 1900
   #define snprintf _snprintf
  #endif
  /* int is 32-bit for both x86 and x64 */

--- a/lib/device.c
+++ b/lib/device.c
@@ -118,7 +118,7 @@ static SOCKET server_connect(const char *host, unsigned short nport)
 		SOCKET sock;
 		int family = addr->ai_family;
 		struct sockaddr *sa = addr->ai_addr;
-		int sa_len = addr->ai_addrlen;
+		int sa_len = (int) addr->ai_addrlen; /* elim. warning on (at least) Win/x64, size_t vs. int/socklen_t */
 
 #else
 


### PR DESCRIPTION
Now this should work better. Some caching issue failed to permanently delete my previous fork and then was later overwritten :\ 