### PR TITLE
editor: rename ClientSocket to SyncClient

### DIFF
--- a/editor/editor.pro
+++ b/editor/editor.pro
@@ -14,14 +14,14 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 !contains(QT, websockets): message("QWebSockets module not found, disabling websocket support...")
 
 # Input
-HEADERS += clientsocket.h \
+HEADERS += syncclient.h \
     mainwindow.h \
     syncdocument.h \
     synctrack.h \
     trackview.h \
     syncpage.h
 
-SOURCES += clientsocket.cpp \
+SOURCES += syncclient.cpp \
     editor.cpp \
     mainwindow.cpp \
     syncdocument.cpp \

--- a/editor/mainwindow.h
+++ b/editor/mainwindow.h
@@ -5,7 +5,6 @@
 #include <QSettings>
 #include <QStringList>
 #include "synctrack.h"
-#include "clientsocket.h"
 
 class QLabel;
 class QAction;
@@ -13,10 +12,10 @@ class QTabWidget;
 class QTcpServer;
 class QWebSocketServer;
 
+class SyncClient;
 class SyncDocument;
 class SyncPage;
 class TrackView;
-class ClientSocket;
 
 class MainWindow : public QMainWindow {
 	Q_OBJECT
@@ -49,7 +48,7 @@ public:
 	QTcpServer *tcpServer;
 	QWebSocketServer *wsServer;
 
-	ClientSocket *clientSocket;
+	SyncClient *syncClient;
 
 	SyncDocument *doc;
 

--- a/editor/syncclient.cpp
+++ b/editor/syncclient.cpp
@@ -1,10 +1,10 @@
-#include "clientsocket.h"
+#include "syncclient.h"
 #include "syncdocument.h"
 
 #include <QDataStream>
 #include <QtEndian>
 
-void ClientSocket::sendSetKeyCommand(const QString &trackName, const SyncTrack::TrackKey &key)
+void SyncClient::sendSetKeyCommand(const QString &trackName, const SyncTrack::TrackKey &key)
 {
 	int trackIndex = trackNames.indexOf(trackName);
 	if (trackIndex < 0)
@@ -28,7 +28,7 @@ void ClientSocket::sendSetKeyCommand(const QString &trackName, const SyncTrack::
 	sendData(data);
 }
 
-void ClientSocket::sendDeleteKeyCommand(const QString &trackName, int row)
+void SyncClient::sendDeleteKeyCommand(const QString &trackName, int row)
 {
 	int trackIndex = trackNames.indexOf(trackName);
 	if (trackIndex < 0)
@@ -42,7 +42,7 @@ void ClientSocket::sendDeleteKeyCommand(const QString &trackName, int row)
 	sendData(data);
 }
 
-void ClientSocket::sendSetRowCommand(int row)
+void SyncClient::sendSetRowCommand(int row)
 {
 	QByteArray data;
 	QDataStream ds(&data, QIODevice::WriteOnly);
@@ -51,7 +51,7 @@ void ClientSocket::sendSetRowCommand(int row)
 	sendData(data);
 }
 
-void ClientSocket::sendPauseCommand(bool pause)
+void SyncClient::sendPauseCommand(bool pause)
 {
 	QByteArray data;
 	QDataStream ds(&data, QIODevice::WriteOnly);
@@ -60,14 +60,14 @@ void ClientSocket::sendPauseCommand(bool pause)
 	sendData(data);
 }
 
-void ClientSocket::sendSaveCommand()
+void SyncClient::sendSaveCommand()
 {
 	QByteArray data;
 	data.append(SAVE_TRACKS);
 	sendData(data);
 }
 
-void ClientSocket::setPaused(bool pause)
+void SyncClient::setPaused(bool pause)
 {
 	if (pause != paused) {
 		sendPauseCommand(pause);
@@ -75,7 +75,7 @@ void ClientSocket::setPaused(bool pause)
 	}
 }
 
-void ClientSocket::requestTrack(const QString &trackName)
+void SyncClient::requestTrack(const QString &trackName)
 {
 	trackNames.append(trackName);
 	emit trackRequested(trackName);

--- a/editor/syncclient.h
+++ b/editor/syncclient.h
@@ -20,11 +20,11 @@ enum {
 	SAVE_TRACKS = 5
 };
 
-class ClientSocket : public QObject {
+class SyncClient : public QObject {
 	Q_OBJECT
 
 public:
-	ClientSocket() : paused(false) { }
+	SyncClient() : paused(false) { }
 
 	virtual void close() = 0;
 	virtual qint64 sendData(const QByteArray &data) = 0;
@@ -77,7 +77,7 @@ protected:
 	bool paused;
 };
 
-class AbstractSocketClient : public ClientSocket {
+class AbstractSocketClient : public SyncClient {
 	Q_OBJECT
 public:
 	explicit AbstractSocketClient(QAbstractSocket *socket) : socket(socket)
@@ -116,7 +116,7 @@ private slots:
 
 class QWebSocket;
 
-class WebSocketClient : public ClientSocket {
+class WebSocketClient : public SyncClient {
 	Q_OBJECT
 public:
 	explicit WebSocketClient(QWebSocket *socket);

--- a/editor/syncdocument.h
+++ b/editor/syncdocument.h
@@ -9,7 +9,6 @@
 #include <QUndoStack>
 #include <QStringList>
 
-#include "clientsocket.h"
 #include "synctrack.h"
 #include "syncpage.h"
 


### PR DESCRIPTION
SyncClient is a much better name, because the socket-ism of the
client is an implementation detail, not a required part of the
interface of the base-class. So let's generalize this a bit so
we don't leak needless details.

While we're at it, tweak includes of the header a bit for minimal
recompilation.