### PR TITLE
player: remove pointless assign

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -250,7 +250,6 @@ void sync_destroy_device(struct sync_device *d)
 #ifndef SYNC_PLAYER
 	if (d->sock != INVALID_SOCKET)
 		closesocket(d->sock);
-	d->sock = INVALID_SOCKET;
 #endif
 
 	for (i = 0; i < (int)d->num_tracks; ++i) {


### PR DESCRIPTION
We're about to free the storage of this variable anyway, so the
assign does little useful.