### PR TITLE
player: do not use closed socket fd

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -185,6 +185,7 @@ static SOCKET server_connect(const char *host, unsigned short nport)
 		}
 
 		closesocket(sock);
+		sock = INVALID_SOCKET;
 	}
 
 #ifdef USE_GETADDRINFO


### PR DESCRIPTION
Noticed by Valgrind. This one is a bit nasty as the file-descriptor
could be reused by the system, and we could end up closing random
file-descriptors as a result.