### PR TITLE
player: fix strncat usage

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -46,9 +46,9 @@ static const char *sync_track_path(const char *base, const char *name)
 	static char temp[FILENAME_MAX];
 	strncpy(temp, base, sizeof(temp) - 1);
 	temp[sizeof(temp) - 1] = '\0';
-	strncat(temp, "_", sizeof(temp) - 1);
-	strncat(temp, path_encode(name), sizeof(temp) - 1);
-	strncat(temp, ".track", sizeof(temp) - 1);
+	strncat(temp, "_", sizeof(temp) - strlen(temp) - 1);
+	strncat(temp, path_encode(name), sizeof(temp) - strlen(temp) - 1);
+	strncat(temp, ".track", sizeof(temp) - strlen(temp) - 1);
 	return temp;
 }
 


### PR DESCRIPTION
The last argument to strncat isn't the total amount of characters
the buffer have room for, but the maximum number of bytes we can
append to the string. This means we need to subtract the amount
already appended.

Spotted by clang-checker.