### PR TITLE
Rename sync_connect to sync_tcp_connect

### DIFF
--- a/examples/example_bass.cpp
+++ b/examples/example_bass.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 		die("out of memory?");
 
 #ifndef SYNC_PLAYER
-	if (sync_connect(rocket, "localhost", SYNC_DEFAULT_PORT))
+	if (sync_tcp_connect(rocket, "localhost", SYNC_DEFAULT_PORT))
 		die("failed to connect to host");
 #endif
 
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
 		double row = bass_get_row(stream);
 #ifndef SYNC_PLAYER
 		if (sync_update(rocket, (int)floor(row), &bass_cb, (void *)&stream))
-			sync_connect(rocket, "localhost", SYNC_DEFAULT_PORT);
+			sync_tcp_connect(rocket, "localhost", SYNC_DEFAULT_PORT);
 #endif
 
 		/* draw */

--- a/lib/device.c
+++ b/lib/device.c
@@ -389,7 +389,7 @@ static int handle_del_key_cmd(SOCKET sock, struct sync_device *data)
 	return sync_del_key(data->tracks[track], row);
 }
 
-int sync_connect(struct sync_device *d, const char *host, unsigned short port)
+int sync_tcp_connect(struct sync_device *d, const char *host, unsigned short port)
 {
 	int i;
 	if (d->sock != INVALID_SOCKET)
@@ -413,6 +413,11 @@ int sync_connect(struct sync_device *d, const char *host, unsigned short port)
 		}
 	}
 	return 0;
+}
+
+int sync_connect(struct sync_device *d, const char *host, unsigned short port)
+{
+	return sync_tcp_connect(d, host, port);
 }
 
 int sync_update(struct sync_device *d, int row, struct sync_cb *cb,

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -32,7 +32,8 @@ struct sync_cb {
 	int (*is_playing)(void *);
 };
 #define SYNC_DEFAULT_PORT 1338
-int sync_connect(struct sync_device *, const char *, unsigned short);
+int sync_tcp_connect(struct sync_device *, const char *, unsigned short);
+int SYNC_DEPRECATED("use sync_tcp_connect instead") sync_connect(struct sync_device *, const char *, unsigned short);
 int sync_update(struct sync_device *, int, struct sync_cb *, void *);
 void sync_save_tracks(const struct sync_device *);
 #endif /* defined(SYNC_PLAYER) */

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -11,6 +11,14 @@ extern "C" {
 
 #include <stddef.h>
 
+#ifdef __GNUC__
+#define SYNC_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define SYNC_DEPRECATED(msg) __declspec(deprecated("is deprecated: " msg))
+#else
+#define SYNC_DEPRECATED(msg)
+#endif
+
 struct sync_device;
 struct sync_track;
 


### PR DESCRIPTION
We might add more transports, so let's not use the generic name sync_connect for TCP.