### PR TITLE
travis-ci: use qt5 instead of qt4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ os:
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update &&
-      brew install qt &&
-      brew install sdl;
+      brew install qt5 &&
+      brew install sdl &&
+      export QMAKE="`brew --prefix qt5`/bin/qmake";
     fi
   - if [ ! -f deps/bass24.zip ]; then
         mkdir -p deps && (


### PR DESCRIPTION
Qt4 doesn't contain QWebSockets, which is required for JavaScript
support. So let's use Qt5 instead.