### PR TITLE
player: use redef-friendly defines

### DIFF
--- a/lib/base.h
+++ b/lib/base.h
@@ -2,8 +2,8 @@
 #define SYNC_BASE_H
 
 #ifdef _MSC_VER
- #define _CRT_SECURE_NO_WARNINGS
- #define _CRT_NONSTDC_NO_DEPRECATE
+ #define _CRT_SECURE_NO_WARNINGS 1
+ #define _CRT_NONSTDC_NO_DEPRECATE 1
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION
When redefining preprocessor defines, they need to exactly match
the previous definition to prevent warnings from being generated.

And if we use the project settings to set _CRT_SECURE_NO_WARNINGS
and/or _CRT_NONSTDC_NO_DEPRECATE, MSVC defines them to "1". So
let's make sure our definition matches what MSVC uses.