### PR TITLE
remove needless GNU-mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-GNU Rocket
+Rocket
 ==========
 
 [![Build status](https://ci.appveyor.com/api/projects/status/dfq8qaedc6mtsefg/branch/master?svg=true)](https://ci.appveyor.com/project/kusma/rocket/branch/master)
 [![Build status](https://travis-ci.org/kusma/rocket.svg?branch=master)](https://travis-ci.org/kusma/rocket)
 [![Gitter](https://badges.gitter.im/kusma/rocket.svg)](https://gitter.im/kusma/rocket?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-GNU Rocket is an intuitive new way of... bah, whatever. It's a sync-tracker,
-a tool for synchronizing music and visuals in demoscene productions. It
+Rocket is an intuitive new way of... bah, whatever. It's a sync-tracker, a
+tool for synchronizing music and visuals in demoscene productions. It
 consists of a GUI editor (using Qt), and an ANSI C library that can either
 communicate with the editor over a network socket, or play back an exported
 data-set.
 
 Compile Editor
 --------------
-The GNU Rocket editor uses qmake as a build-system abstraction, which can
-be used to output Makefiles, Visual Studio project files or can be built
+The Rocket editor uses qmake as a build-system abstraction, which can be
+used to output Makefiles, Visual Studio project files or can be built
 directly from QtCreator. See the qmake documentation for details.
 
 Compile Example
 ---------------
-GNU Rocket contains an example client called example\_bass. This is a simple
+Rocket contains an example client called example\_bass. This is a simple
 OpenGL, SDL 1.2 and BASS audio library application, that demonstrates how to
-use the GNU Rocket API.
+use the Rocket API.
 
 Before compiling the example, you need to make sure you have recent [SDL](http://www.libsdl.org/)
 and [BASS](http://www.un4seen.com/) libraries and includes.
@@ -47,10 +47,10 @@ JavaScript support. Have a look at [js/README.md](js/README.md) for more informa
 
 Using the editor
 ----------------
-The GNU Rocket editor is laid out like a music-tracker; tracks (or columns)
-and rows. Each track represents a separate "variable" in the demo, over the
-entire time-domain of the demo. Each row represents a specific point in time,
-and consists of a set of key frames. The key frames are interpolated over time
+The Rocket editor is laid out like a music-tracker; tracks (or columns) and
+rows. Each track represents a separate "variable" in the demo, over the entire
+time-domain of the demo. Each row represents a specific point in time, and
+consists of a set of key frames. The key frames are interpolated over time
 according to their interpolation modes.
 
 Interpolation modes
@@ -71,8 +71,8 @@ interpolation modes are the following:
 
 Keyboard shortcuts
 -------------------
-Some of the GNU Rocket editor's features are available through the menu and
-some keyboard shortcut. Here's a list of the supported keyboard shortcuts:
+Some of the Rocket editor's features are available through the menu and some
+keyboard shortcut. Here's a list of the supported keyboard shortcuts:
 
 | Shortcut                 | Action                       |
 |:-------------------------|:-----------------------------|
@@ -99,7 +99,7 @@ some keyboard shortcut. Here's a list of the supported keyboard shortcuts:
 
 Alternatives and ports
 ----------------------
-* [PBRocket](https://github.com/dartcode/pbrocket), a PureBasic port of the GNU Rocket editor, client and player.
+* [PBRocket](https://github.com/dartcode/pbrocket), a PureBasic port of the Rocket editor, client and player.
 * [RocketEditor](https://github.com/emoon/rocket/tree/master/ogl_editor), an alternative editor written in pure C using OpenGL for the GUI.
 * [GroundControl](https://github.com/edoreshef/ground-control), an alternative editor written in C# using WPF for the GUI.
 * [RocketNet](https://github.com/kebby/RocketNet), a pure .NET implementation of the client and player.
@@ -107,5 +107,5 @@ Alternatives and ports
 
 Bugs and feedback
 -----------------
-Please report bugs or other feedback to the GNU Rocket mailing list:
+Please report bugs or other feedback to the Rocket mailing list:
 gnu-rocket@googlegroups.com

--- a/contrib/logo.svg
+++ b/contrib/logo.svg
@@ -2,7 +2,7 @@
 
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
-     version="1.1" width="128" height="128" id="GNU Rocket logo">
+     version="1.1" width="128" height="128" id="Rocket logo">
 
 	<style type="text/css" >
 		<![CDATA[

--- a/editor/mainwindow.cpp
+++ b/editor/mainwindow.cpp
@@ -65,7 +65,7 @@ MainWindow::MainWindow() :
 		setStatusText(QString("Could not start server: %1").arg(tcpServer->errorString()));
 
 #ifdef QT_WEBSOCKETS_LIB
-	wsServer = new QWebSocketServer("GNU Rocket Editor", QWebSocketServer::NonSecureMode);
+	wsServer = new QWebSocketServer("Rocket Editor", QWebSocketServer::NonSecureMode);
 	connect(wsServer, SIGNAL(newConnection()),
 	        this, SLOT(onNewWsConnection()));
 
@@ -426,7 +426,7 @@ void MainWindow::fileQuit()
 {
 	if (doc->isModified()) {
 		QMessageBox::StandardButton res = QMessageBox::question(
-		    this, "GNU Rocket", "Save before exit?",
+		    this, "Rocket", "Save before exit?",
 		    QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
 		if (res == QMessageBox::Yes) {
 			fileSave();

--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,6 @@
 jsRocket
 ========
-Lets you use GNU Rocket with your JavaScript / Browser demo.
+Lets you use Rocket with your JavaScript / Browser demo.
 
 js?
 ---
@@ -127,7 +127,7 @@ function render() {
 }
 ```
 
-**GNU Rocket**
+**Rocket**
 Has WebSocket support now, thanks kusma <3, no need for Websockify anymore.
 
 Demos

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsRocket",
-  "description": "js connector for GNU Rocket",
+  "description": "js connector for Rocket",
   "version": "0.0.1",
   "homepage": "https://github.com/kusma/rocket",
   "author": {


### PR DESCRIPTION
This project is not a part of the GNU-project, and the old GNU
Rocket joke isn't really that funny. So let's avoid confusion for
outsiders, and just talk about "Rocket" instead of "GNU Rocket".

There's still some cases that have been left due to backwards
compatibility. I might try to write some transitional code at some
later point, but for now this is a step in the right direction.